### PR TITLE
Remove rimraf inclusion

### DIFF
--- a/lib/Gadget.js
+++ b/lib/Gadget.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const async = require('async')
-const rimraf = require('rimraf')
 
 const base = '/sys/kernel/config'
 const usb_gadgets = `${base}/usb_gadget`


### PR DESCRIPTION
Fixes error thrown due to missing rimraf module, which is neither used nor listed as dependency.